### PR TITLE
Electronic Observer 4.0.2.1

### DIFF
--- a/ElectronicObserver/Properties/AssemblyInfo.cs
+++ b/ElectronicObserver/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using ElectronicObserver.Utility;
 // すべての値を指定するか、下のように '*' を使ってビルドおよびリビジョン番号を
 // 既定値にすることができます:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.0.2.0")]
-[assembly: AssemblyFileVersion("4.0.2.0")]
+[assembly: AssemblyVersion("4.0.2.1")]
+[assembly: AssemblyFileVersion("4.0.2.1")]

--- a/ElectronicObserver/Resource/Record/ResourceRecord.cs
+++ b/ElectronicObserver/Resource/Record/ResourceRecord.cs
@@ -254,7 +254,7 @@ namespace ElectronicObserver.Resource.Record
 				target = new DateTime(now.Year, now.Month, now.Day, 14, 0, 0);
 			}
 
-			return GetRecord(target);
+			return GetRecord(target.Add(DateTimeHelper.GetTimeDifference()));
 		}
 
 		/// <summary>
@@ -274,7 +274,7 @@ namespace ElectronicObserver.Resource.Record
 				target = new DateTime(now.Year, now.Month, now.Day, 2, 0, 0);
 			}
 
-			return GetRecord(target);
+			return GetRecord(target.Add(DateTimeHelper.GetTimeDifference()));
 		}
 
 		/// <summary>
@@ -284,7 +284,7 @@ namespace ElectronicObserver.Resource.Record
 		{
 			DateTime now = DateTime.UtcNow + new TimeSpan(9, 0, 0);
 
-			return GetRecord(new DateTime(now.Year, now.Month, 1));
+			return GetRecord(new DateTime(now.Year, now.Month, 1).Add(DateTimeHelper.GetTimeDifference()));
 		}
 
 

--- a/ElectronicObserver/Utility/SoftwareInformation.cs
+++ b/ElectronicObserver/Utility/SoftwareInformation.cs
@@ -37,7 +37,7 @@ namespace ElectronicObserver.Utility
 		/// <summary>
 		/// バージョン(英語)
 		/// </summary>
-		public static string VersionEnglish => "4.0.2";
+		public static string VersionEnglish => "4.0.2.1";
 
 
 


### PR DESCRIPTION
Fixed #67 EO was requesting record in JST time instead of local time (e.g: 14:00 instead of 12:00 (UTC+7)).